### PR TITLE
Fix the order of building the images in workflows

### DIFF
--- a/.github/workflows/docker-pytorch.yml
+++ b/.github/workflows/docker-pytorch.yml
@@ -10,8 +10,10 @@ env:
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
-  push:
-    branches: ['master']
+  workflow_run:
+    workflows: ["base"]
+    types:
+      - completed
 
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:

--- a/.github/workflows/docker-pytorch.yml
+++ b/.github/workflows/docker-pytorch.yml
@@ -8,7 +8,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}/pytorch
 
 
-# Configures this workflow to run every time a change is pushed to the branch called `release`.
+# Configures this workflow to run every time the "base" workflow was successfully completed
 on:
   workflow_run:
     workflows: ["base"]


### PR DESCRIPTION
Hi,

I think the workflows are currently set up such that the images are built in parallel. However, the pytorch image depends on the base image. This PR should fix this.